### PR TITLE
Implement cmdport parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,13 @@
 #   Whether to log statistics about NTP clients.
 #   Default: false
 #
+# [*cmdport*]
+#   The port that chronyd will listen for control packets. Set to 0 to
+#   disable listening for control packets. This does not affect listening
+#   for control packets on a Unix socket. By default (and when unspecified)
+#   chronyd uses udp/323.
+#   Default: undef
+#
 # [*offline*]
 #   Whether the NTP client should start in offline mode. In this mode, clients
 #   must issue the chronyc online command to begin synchronization (though
@@ -133,6 +140,7 @@ class chrony (
   Array[String] $client_allow               = [],
   Array[String] $client_deny                = [],
   Boolean $client_log                       = false,
+  Optional[Integer] $cmdport                = undef,
   Boolean $offline                          = false,
   Array[String] $refclock                   = [],
   String $config_file                       = '/etc/chrony.conf',

--- a/templates/chronyd.conf.erb
+++ b/templates/chronyd.conf.erb
@@ -37,6 +37,9 @@ deny <%= client_deny %>
 <% [@bindcmdaddress].flatten.each do |bindcmdaddress| -%>
 bindcmdaddress <%= bindcmdaddress %>
 <% end -%>
+<% if @cmdport -%>
+cmdport <%= @cmdport %>
+<% end -%>
 
 <% if @udlc -%>
 local stratum 10


### PR DESCRIPTION
This adds the `cmdport` parameter to the chrony.conf template. `cmdport` controls the UDP port that chronyd listens on for commands. I needed to set it to `0` to disable listening.

By default, it's `undef` which means no changes are made to everyone's config.