### PR TITLE
Set chrony_version to nil if not installed

### DIFF
--- a/lib/facter/chrony_version.rb
+++ b/lib/facter/chrony_version.rb
@@ -1,9 +1,8 @@
 Facter.add('chrony_version') do
     confine :kernel => 'Linux'
     setcode do
-        version = Facter::Core::Execution.exec("/bin/rpm -q --queryformat '%{VERSION}' chrony")
-        if version != nil
-            version
+        if Facter::Core::Execution.which("chronyd")
+            Facter::Core::Execution.execute("/bin/rpm -q --queryformat '%{VERSION}' chrony")
         else
             nil
         end


### PR DESCRIPTION
Previously when chrony_version is passed to Gem::Version.new in chronyd.conf.erb, it was possible to cause an error if chrony wasn't yet installed (a fresh deployment). This tests if chrony exists before letting rpm set the fact to 'package chrony is not installed' (not a valid version string).

However, it's also worth noting that this case (chrony not installed yet) causes the first run of Puppet to set this to 'nil', so regardless of the actual version of Chrony being installed. The two lines in the template conditional always get added at first, then removed in a subsequent run. It's probably not too harmful, but it seems unclean to require two Puppet runs before the config is correct. You can see this behavior by running this module on a system without Chrony.

Also, are you looking to publish this on Forge? Or perhaps add to voxpupuli? I'd love to be able to just point my Puppetfile at a Forge repo vs the longer GitHub reference.